### PR TITLE
Create Astro static site with GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install, build, and upload your site
+        uses: withastro/action@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.dist
+.astro
+.DS_Store
+.env
+.env.*
+.npmrc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# astro-pages
+# Astro Pages Starter
+
+This repository contains a minimal Astro site wired for GitHub Pages deployments. It follows the guidelines from the prompt:
+
+- **Astro** powers a static, content-focused site with routes in `src/pages` and Markdown posts in `src/content/posts`.
+- **GitHub Pages** hosts the generated build through the official `withastro/action` workflow located in `.github/workflows/deploy.yml`.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server runs on [http://localhost:4321](http://localhost:4321) by default. Modify content in `src/pages` or add new Markdown files under `src/content/posts` to see live updates.
+
+## Project structure
+
+```
+├── public/               # Static assets copied directly to the build output
+├── src/
+│   ├── components/       # Reusable layouts and UI pieces
+│   ├── content/          # Content collections configuration + Markdown posts
+│   ├── pages/            # Route-based `.astro` files (home, about, blog, posts)
+│   └── styles/           # Global stylesheet
+├── astro.config.mjs      # Configures site URL and base path for GitHub Pages
+├── package.json          # Astro dependency and scripts
+└── tsconfig.json         # Strict type checking preset from Astro
+```
+
+## Deploying to GitHub Pages
+
+1. Update `site` and `base` in `astro.config.mjs` with your GitHub Pages URL and repository name.
+2. Ensure GitHub Pages is configured to use GitHub Actions as the source.
+3. Push to the `main` branch. The workflow builds the site and publishes the static output to the `gh-pages` branch automatically.
+
+Optional: add `public/CNAME` with your custom domain and set `site` to the custom domain if you plan to use one.
+
+## Available scripts
+
+- `npm run dev` – Start the local development server.
+- `npm run build` – Generate the production-ready static site in `dist/`.
+- `npm run preview` – Preview the build output locally.
+- `npm run astro` – Access the Astro CLI directly.
+
+Happy shipping!

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'astro/config';
+
+// https://docs.astro.build/en/reference/configuration-reference/
+export default defineConfig({
+  site: 'https://example.github.io',
+  base: '/astro-pages',
+  markdown: {
+    drafts: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "astro-pages",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "^4.15.9"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="astroGradient" x1="12" y1="16" x2="116" y2="112" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4F46E5" />
+      <stop offset="1" stop-color="#22D3EE" />
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="96" height="96" rx="24" fill="url(#astroGradient)" />
+  <path d="M64 38L82 90H73L68.5 76H59.5L55 90H46L64 38Z" fill="white" />
+</svg>

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -1,0 +1,41 @@
+import '../styles/global.css';
+
+const { title = 'Astro Pages', description = 'Static sites without the maintenance headache.' } = Astro.props;
+const links = [
+  { href: '/', label: 'Home' },
+  { href: '/about', label: 'About' },
+  { href: '/blog', label: 'Blog' },
+];
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <header>
+      <nav>
+        <a href="/" class="brand" aria-label="Astro Pages home">Astro Pages</a>
+        <ul>
+          {links.map((link) => (
+            <li>
+              <a href={link.href} aria-current={Astro.url.pathname === link.href ? 'page' : undefined}>
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <slot />
+    </main>
+    <footer>
+      Built with <a href="https://astro.build">Astro</a> &middot; Deploys from GitHub Pages using the official Astro Action
+    </footer>
+  </body>
+</html>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,16 @@
+import { defineCollection, z } from 'astro:content';
+
+const posts = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+    tags: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = {
+  posts,
+};

--- a/src/content/posts/deploying-to-github-pages.md
+++ b/src/content/posts/deploying-to-github-pages.md
@@ -1,0 +1,16 @@
+---
+title: Deploying Astro on GitHub Pages
+description: Step-by-step notes on configuring site and base for a repository-hosted Astro site.
+pubDate: 2024-08-08
+tags:
+  - github-pages
+  - automation
+---
+
+Deploying to GitHub Pages is as simple as connecting your repository and enabling the official workflow.
+
+1. Set `site` to your GitHub Pages domain and `base` to your repository slug inside `astro.config.mjs`.
+2. Add `.github/workflows/deploy.yml` with the `withastro/action@v3` build step followed by `actions/deploy-pages@v4`.
+3. Push to `main`. GitHub Actions will build your static output and publish it under the `gh-pages` branch automatically.
+
+Once Pages is enabled in repository settings, every merge to `main` updates the live site in a few minutes.

--- a/src/content/posts/hello-astro.md
+++ b/src/content/posts/hello-astro.md
@@ -1,0 +1,18 @@
+---
+title: Welcome to Astro Pages
+description: Learn what this demo site offers and how it stays fast, friendly, and easy to host.
+pubDate: 2024-08-01
+tags:
+  - astro
+  - static-sites
+---
+
+Whether you are building a personal site or a microsite for a campaign, Astro keeps the workflow light. This starter pairs Astro's island architecture with GitHub Pages so you can ship a production-ready static site with every push.
+
+Key highlights:
+
+- **Content-first** templates that render HTML by default.
+- **Zero JavaScript by default**, with the option to sprinkle interactive islands when you need them.
+- **Push-to-deploy** via the official `withastro/action` so your `main` branch is always live.
+
+Explore the rest of the site to see how pages and Markdown posts live together inside a tidy project structure.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,23 @@
+---
+import Layout from '../components/Layout.astro';
+---
+
+<Layout title="About this project" description="Understand how this Astro + GitHub Pages starter is organized.">
+  <article class="prose">
+    <h1>About the site</h1>
+    <p>
+      This project is intentionally lightweight so you can extend it quickly. Astro handles routing, Markdown rendering, and build optimizations while GitHub Pages hosts the generated HTML.
+    </p>
+    <h2>Project layout</h2>
+    <ul>
+      <li><code>src/pages</code> contains route-based `.astro` files.</li>
+      <li><code>src/components</code> stores shared layouts and partials.</li>
+      <li><code>src/content/posts</code> holds Markdown blog posts with typed frontmatter.</li>
+      <li><code>public</code> includes any static assets copied directly into the final build.</li>
+    </ul>
+    <h2>Deployment</h2>
+    <p>
+      A single GitHub Actions workflow builds the site with <code>withastro/action@v3</code> and publishes to the <code>gh-pages</code> branch using <code>actions/deploy-pages@v4</code>. Update <code>astro.config.mjs</code> with your domain so links resolve correctly.
+    </p>
+  </article>
+</Layout>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,31 @@
+---
+import Layout from '../../components/Layout.astro';
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('posts');
+  return posts
+    .filter((post) => !post.data.draft)
+    .map((post) => ({
+      params: { slug: post.slug },
+      props: { post },
+    }));
+}
+
+const { post } = Astro.props;
+const { Content } = await post.render();
+---
+
+<Layout title={`${post.data.title} | Astro Pages`} description={post.data.description}>
+  <article class="prose">
+    <p><a href="/blog">← Back to blog</a></p>
+    <h1>{post.data.title}</h1>
+    <p><strong>{post.data.pubDate.toLocaleDateString(undefined, { dateStyle: 'medium' })}</strong></p>
+    <ul class="tag-list">
+      {post.data.tags.map((tag) => (
+        <li class="tag">{tag}</li>
+      ))}
+    </ul>
+    <Content />
+  </article>
+</Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,37 @@
+---
+import Layout from '../components/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('posts'))
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+---
+
+<Layout title="Blog" description="Fresh notes about this Astro + GitHub Pages starter.">
+  <section class="prose">
+    <h1>Blog</h1>
+    <p>Thoughts on shipping fast, static-friendly sites with Astro and GitHub Pages.</p>
+  </section>
+
+  <div class="card-grid">
+    {posts.map((post) => (
+      <article class="card">
+        <h3>{post.data.title}</h3>
+        <p>{post.data.description}</p>
+        <p><strong>{post.data.pubDate.toLocaleDateString(undefined, { dateStyle: 'medium' })}</strong></p>
+        <ul class="tag-list">
+          {post.data.tags.map((tag) => (
+            <li class="tag">{tag}</li>
+          ))}
+        </ul>
+        <a class="button secondary" href={`/blog/${post.slug}`}>Read post</a>
+      </article>
+    ))}
+    {posts.length === 0 && (
+      <article class="card">
+        <h3>No posts yet</h3>
+        <p>Add a Markdown file with frontmatter to <code>src/content/posts</code> to publish your first entry.</p>
+      </article>
+    )}
+  </div>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,64 @@
+---
+import Layout from '../components/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('posts'))
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 3);
+---
+
+<Layout title="Astro Pages" description="A minimal Astro starter wired for GitHub Pages deployments.">
+  <section class="hero">
+    <h1>Static content, automated deploys.</h1>
+    <p>
+      Ship a polished marketing or documentation site without provisioning servers. Astro builds static HTML by default and GitHub Pages deploys the output on every push.
+    </p>
+    <div class="button-row">
+      <a class="button" href="/blog">Read the latest updates</a>
+      <a class="button secondary" href="https://docs.astro.build/en/guides/deploy/github/">View the deployment guide</a>
+    </div>
+  </section>
+
+  <section>
+    <h2>Quick links</h2>
+    <div class="card-grid">
+      <article class="card">
+        <h3>Content collections</h3>
+        <p>Markdown posts live in <code>src/content/posts</code>. Add metadata with frontmatter and Astro will type-check it for you.</p>
+      </article>
+      <article class="card">
+        <h3>Built-in SEO</h3>
+        <p>Layouts set document titles and descriptions, while Astro handles clean URLs and meta tags automatically.</p>
+      </article>
+      <article class="card">
+        <h3>Pages &amp; partials</h3>
+        <p>Create additional routes under <code>src/pages</code> and share UI with reusable components in <code>src/components</code>.</p>
+      </article>
+    </div>
+  </section>
+
+  <section>
+    <h2>Latest posts</h2>
+    <div class="card-grid">
+      {posts.map((post) => (
+        <article class="card">
+          <h3>{post.data.title}</h3>
+          <p>{post.data.description}</p>
+          <ul class="tag-list">
+            {post.data.tags.map((tag) => (
+              <li class="tag">{tag}</li>
+            ))}
+          </ul>
+          <a class="button secondary" href={`/blog/${post.slug}`}>Read more</a>
+        </article>
+      ))}
+      {posts.length === 0 && (
+        <article class="card">
+          <h3>No posts yet</h3>
+          <p>Add Markdown files to <code>src/content/posts</code> to see them listed here.</p>
+        </article>
+      )}
+    </div>
+  </section>
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,180 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.6;
+  background-color: #f6f7fb;
+  color: #1a1f36;
+}
+
+a {
+  color: #4f46e5;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(79,70,229,0.05) 0%, rgba(255,255,255,0) 60%);
+}
+
+main {
+  width: min(960px, 90vw);
+  margin: 0 auto;
+  padding: 2.5rem 0 4rem;
+}
+
+header {
+  backdrop-filter: blur(8px);
+  background: rgba(255, 255, 255, 0.7);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 auto;
+  width: min(960px, 90vw);
+  padding: 1rem 0;
+}
+
+nav ul {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  border-radius: 9999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+nav a:hover,
+nav a[aria-current="page"] {
+  background: rgba(79, 70, 229, 0.1);
+}
+
+footer {
+  padding: 2rem 0;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  margin-top: 4rem;
+  text-align: center;
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 2.5rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 20px 40px -24px rgba(79, 70, 229, 0.35);
+  padding: 1.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tag {
+  background: rgba(79, 70, 229, 0.12);
+  color: #4338ca;
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.hero {
+  padding: 4rem 0 3rem;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 4vw, 3.25rem);
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  max-width: 620px;
+  margin: 0 auto;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.button-row {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  background: #4f46e5;
+  color: white;
+  box-shadow: 0 12px 25px -10px rgba(79, 70, 229, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.secondary {
+  background: transparent;
+  color: #4f46e5;
+  border: 1px solid rgba(79, 70, 229, 0.3);
+  box-shadow: none;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 35px -20px rgba(79, 70, 229, 0.8);
+}
+
+.prose {
+  max-width: 680px;
+  margin: 0 auto;
+  font-size: 1.05rem;
+}
+
+.prose h2 {
+  font-size: 2rem;
+  margin-top: 2.5rem;
+}
+
+.prose p {
+  color: rgba(15, 23, 42, 0.75);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}


### PR DESCRIPTION
## Summary
- scaffold an Astro site with layout, home, about, blog listing, and Markdown-driven posts
- add global styling, favicon, and a content collection configuration
- configure GitHub Pages deployment via withastro/action and document project usage

## Testing
- not run (npm install repeatedly stalled in the execution environment)

------
https://chatgpt.com/codex/tasks/task_b_68d1bcfa87008330a01391edac025aff