### PR TITLE
Add Fathom analytics tracking

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -24,6 +24,7 @@ const links = [
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href={joinPath(import.meta.env.BASE_URL, "favicon.svg")} />
+    <script src="https://cdn.usefathom.com/script.js" data-site="BYOOUUTF" defer></script>
   </head>
   <body>
     <header>


### PR DESCRIPTION
## Summary
- embed the Fathom Analytics script with the provided site ID in the shared layout so all pages are tracked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d9c29fd49c83309ba810767d93596a